### PR TITLE
modify btc on icp from 0 to 237

### DIFF
--- a/content/layers/internetcomputer.json
+++ b/content/layers/internetcomputer.json
@@ -8,7 +8,7 @@
   "purpose": "General",
   "btcBridge": "Permissionless Multisig",
   "settlement": "Offchain",
-  "btcLocked": 0,
+  "btcLocked": 237,
   "executionEnv": "Bitcoin Script",
   "consensus": "PoM",
   "nativeToken": "-",


### PR DESCRIPTION
On the ICP dashboard https://dashboard.internetcomputer.org/bitcoin we can see the number of ckBTC minted is 237.