### PR TITLE
Add type filters popover

### DIFF
--- a/app/bitcoinonly/page.tsx
+++ b/app/bitcoinonly/page.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import React, { useState } from "react";
 import { allLayers } from "@/util/layer_index";
 import { allInfrastructures } from "@/util/infrastructure_index";
 import BitcoinonlyTable from "@/components/tables/bitcoinonlyTable";
@@ -11,9 +8,11 @@ export default function Home() {
         a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
     );
 
-    const sortedEverything = [...allLayers, ...allInfrastructures].sort(
-        (a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
-    );
+    const sortedEverything = [...allLayers, ...allInfrastructures]
+        .filter((item) => item.bitcoinOnly)
+        .sort((a, b) =>
+            a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
+        );
 
     const typeFilters = [
         ...new Set(

--- a/app/bitcoinonly/page.tsx
+++ b/app/bitcoinonly/page.tsx
@@ -15,10 +15,23 @@ export default function Home() {
         (a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
     );
 
+    const typeFilters = [
+        ...new Set(
+            sortedEverything.map((item) =>
+                "layerType" in item ? item.layerType : item.infrastructureType,
+            ),
+        ),
+    ];
+
     const layerHeaders = [
         { name: "Name", showSorting: true, mobileLabel: "Name" },
         { name: "Risk", showSorting: false, mobileLabel: "Risk" },
-        { name: "Type", showSorting: true, mobileLabel: "Type" },
+        {
+            name: "Type",
+            showSorting: true,
+            mobileLabel: "Type",
+            filterOptions: typeFilters,
+        },
         { name: "Status", showSorting: true, mobileLabel: "Status" },
         { name: "Category", showSorting: true, mobileLabel: "Category" },
         // {

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,3 +85,69 @@ section {
     --color-risk-unverified-text: #a50f11;
     --color-risk-unverified-icon: #c80d0f;
 }
+
+@layer base {
+    :root {
+        --background: 0 0% 100%;
+        --foreground: 222.2 84% 4.9%;
+        --card: 0 0% 100%;
+        --card-foreground: 222.2 84% 4.9%;
+        --popover: 0 0% 100%;
+        --popover-foreground: 222.2 84% 4.9%;
+        --primary: 222.2 47.4% 11.2%;
+        --primary-foreground: 210 40% 98%;
+        --secondary: 210 40% 96.1%;
+        --secondary-foreground: 222.2 47.4% 11.2%;
+        --muted: 210 40% 96.1%;
+        --muted-foreground: 215.4 16.3% 46.9%;
+        --accent: 210 40% 96.1%;
+        --accent-foreground: 222.2 47.4% 11.2%;
+        --destructive: 0 84.2% 60.2%;
+        --destructive-foreground: 210 40% 98%;
+        --border: 214.3 31.8% 91.4%;
+        --input: 214.3 31.8% 91.4%;
+        --ring: 222.2 84% 4.9%;
+        --radius: 0.5rem;
+        --chart-1: 12 76% 61%;
+        --chart-2: 173 58% 39%;
+        --chart-3: 197 37% 24%;
+        --chart-4: 43 74% 66%;
+        --chart-5: 27 87% 67%;
+    }
+
+    .dark {
+        --background: 222.2 84% 4.9%;
+        --foreground: 210 40% 98%;
+        --card: 222.2 84% 4.9%;
+        --card-foreground: 210 40% 98%;
+        --popover: 222.2 84% 4.9%;
+        --popover-foreground: 210 40% 98%;
+        --primary: 210 40% 98%;
+        --primary-foreground: 222.2 47.4% 11.2%;
+        --secondary: 217.2 32.6% 17.5%;
+        --secondary-foreground: 210 40% 98%;
+        --muted: 217.2 32.6% 17.5%;
+        --muted-foreground: 215 20.2% 65.1%;
+        --accent: 217.2 32.6% 17.5%;
+        --accent-foreground: 210 40% 98%;
+        --destructive: 0 62.8% 30.6%;
+        --destructive-foreground: 210 40% 98%;
+        --border: 217.2 32.6% 17.5%;
+        --input: 217.2 32.6% 17.5%;
+        --ring: 212.7 26.8% 83.9%;
+        --chart-1: 220 70% 50%;
+        --chart-2: 160 60% 45%;
+        --chart-3: 30 80% 55%;
+        --chart-4: 280 65% 60%;
+        --chart-5: 340 75% 55%;
+    }
+}
+
+@layer base {
+    * {
+        @apply border-border;
+    }
+    body {
+        @apply bg-background text-foreground;
+    }
+}

--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -10,9 +10,22 @@ export default function Home() {
         a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
     );
 
+    const typeFilters = [
+        ...new Set(
+            sortedInfrastructures.map(
+                (infrastructure) => infrastructure.infrastructureType,
+            ),
+        ),
+    ];
+
     const infrastructureHeaders = [
         { name: "Name", showSorting: true, mobileLabel: "Name" },
-        { name: "Type", showSorting: true, mobileLabel: "Type" },
+        {
+            name: "Type",
+            showSorting: true,
+            mobileLabel: "Type",
+            filterOptions: typeFilters,
+        },
         { name: "Status", showSorting: true, mobileLabel: "Status" },
         {
             name: "Unit of Account",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                     attribute="class"
                     defaultTheme="system"
                     enableSystem
+                    forcedTheme="light"
                 >
                     <div className="mx-auto min-h-screen bg-bg_primary">
                         <Navbar />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,8 +15,6 @@ export default function Home() {
         a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
     );
 
-    console.log(allLayers);
-
     const typeFilters = [
         ...new Set(sortedLayers.map((layer) => layer.layerType)),
     ];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,10 +15,25 @@ export default function Home() {
         a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
     );
 
+    console.log(allLayers);
+
+    const typeFilters = [
+        ...new Set(sortedLayers.map((layer) => layer.layerType)),
+    ];
+
     const layerHeaders = [
-        { name: "Name", showSorting: true, mobileLabel: "Name" },
+        {
+            name: "Name",
+            showSorting: true,
+            mobileLabel: "Name",
+        },
         { name: "Risk", showSorting: false, mobileLabel: "Risk" },
-        { name: "Type", showSorting: true, mobileLabel: "Type" },
+        {
+            name: "Type",
+            showSorting: true,
+            mobileLabel: "Type",
+            filterOptions: typeFilters,
+        },
         { name: "Status", showSorting: true, mobileLabel: "Status" },
         {
             name: "Unit of Account",

--- a/components.json
+++ b/components.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://ui.shadcn.com/schema.json",
+    "style": "default",
+    "rsc": true,
+    "tsx": true,
+    "tailwind": {
+        "config": "tailwind.config.ts",
+        "css": "app/globals.css",
+        "baseColor": "slate",
+        "cssVariables": true,
+        "prefix": ""
+    },
+    "aliases": {
+        "components": "@/components",
+        "utils": "@/lib/utils"
+    }
+}

--- a/components/tables/bitcoinonlyTable.tsx
+++ b/components/tables/bitcoinonlyTable.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import { Layer } from "@/components/layer/layerProps";

--- a/components/tables/bitcoinonlyTable.tsx
+++ b/components/tables/bitcoinonlyTable.tsx
@@ -53,7 +53,14 @@ const LayerImage = ({ src, title }: { src: string; title: string }) => {
 };
 
 const BitcoinonlyTable = ({ data, headers }: Props) => {
-    const [filter, setFilter] = useQueryState("filter");
+    const [status, setStatus] = useQueryState("status", {
+        defaultValue: "Mainnet",
+    });
+    const [types] = useQueryState<string[]>("type", {
+        defaultValue: [],
+        parse: (value) => value.split(",").filter(Boolean),
+        serialize: (value) => value.join(","),
+    });
 
     const [sortedData, setSortedData] = useState(data);
     const [mobileActiveTab, setMobileActiveTab] = useState<TableTabKey>("Risk");
@@ -61,6 +68,22 @@ const BitcoinonlyTable = ({ data, headers }: Props) => {
     useEffect(() => {
         handleSort("Name", true);
     }, []);
+
+    useEffect(() => {
+        if (types.length > 0) {
+            setSortedData(
+                data.filter((item) =>
+                    types.includes(
+                        isLayer(item)
+                            ? item.layerType
+                            : item.infrastructureType,
+                    ),
+                ),
+            );
+        } else {
+            setSortedData(data);
+        }
+    }, [types, data]);
 
     const handleSort = (header: string, ascending: boolean) => {
         const sorted = [...sortedData].sort((a, b) => {
@@ -101,13 +124,13 @@ const BitcoinonlyTable = ({ data, headers }: Props) => {
     };
 
     const handleFilter = (header: string, value: string) => {
-        setFilter(value as "Mainnet" | "Testnet" | "All");
+        setStatus(value as "Mainnet" | "Testnet" | "All");
     };
 
     const filteredData = sortedData.filter((item) => {
         if (!item.bitcoinOnly) return false;
-        if (filter === "Mainnet") return item.live === "Mainnet";
-        if (filter === "Testnet") return item.live !== "Mainnet";
+        if (status === "Mainnet") return item.live === "Mainnet";
+        if (status === "Testnet") return item.live !== "Mainnet";
         return true;
     });
 
@@ -125,15 +148,15 @@ const BitcoinonlyTable = ({ data, headers }: Props) => {
                 <div className="justify-start items-start gap-4 inline-flex">
                     <div
                         className={`h-[30px] px-4 py-[5px] rounded-full border-2 justify-center items-center gap-1.5 flex cursor-pointer ${
-                            filter === "Mainnet"
+                            status === "Mainnet"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("Mainnet")}
+                        onClick={() => setStatus("Mainnet")}
                     >
                         <div
                             className={`text-center text-sm font-medium leading-tight ${
-                                filter === "Mainnet"
+                                status === "Mainnet"
                                     ? "text-orange-600"
                                     : "text-slate-600"
                             }`}
@@ -143,16 +166,16 @@ const BitcoinonlyTable = ({ data, headers }: Props) => {
                     </div>
                     <div
                         className={`h-[30px] rounded-full border-2 justify-center items-center gap-1 flex cursor-pointer ${
-                            filter === "Testnet"
+                            status === "Testnet"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("Testnet")}
+                        onClick={() => setStatus("Testnet")}
                     >
                         <div className="grow shrink basis-0 h-[30px] px-4 py-[5px] justify-center items-center gap-1.5 flex">
                             <div
                                 className={`text-center text-sm font-medium leading-tight ${
-                                    filter === "Testnet"
+                                    status === "Testnet"
                                         ? "text-orange-600"
                                         : "text-slate-600"
                                 }`}
@@ -163,16 +186,16 @@ const BitcoinonlyTable = ({ data, headers }: Props) => {
                     </div>
                     <div
                         className={`h-[30px] rounded-full border-2 justify-center items-center gap-1 flex cursor-pointer ${
-                            filter === "All"
+                            status === "All"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("All")}
+                        onClick={() => setStatus("All")}
                     >
                         <div className="grow shrink basis-0 h-[30px] px-4 py-[5px] justify-center items-center gap-1.5 flex">
                             <div
                                 className={`text-center text-sm font-medium leading-tight ${
-                                    filter === "All"
+                                    status === "All"
                                         ? "text-orange-600"
                                         : "text-slate-600"
                                 }`}

--- a/components/tables/filter-popover.tsx
+++ b/components/tables/filter-popover.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const FilterPopover = ({ filters }: Props) => {
-    const filterOptions = filters.length > 0 ? filters : [];
+    const filterOptions = filters.length > 0 ? filters.sort() : [];
     const [queryFilters, setQueryFilters] = useQueryState<string[]>("type", {
         defaultValue: [],
         parse: (value) => value.split(",").filter(Boolean),

--- a/components/tables/filter-popover.tsx
+++ b/components/tables/filter-popover.tsx
@@ -1,0 +1,109 @@
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { useQueryState } from "nuqs";
+import { useState } from "react";
+
+interface Props {
+    filters: string[];
+}
+
+const FilterPopover = ({ filters }: Props) => {
+    const filterOptions = filters.length > 0 ? filters : [];
+    const [queryFilters, setQueryFilters] = useQueryState<string[]>("type", {
+        defaultValue: [],
+        parse: (value) => value.split(",").filter(Boolean),
+        serialize: (value) => value.join(","),
+    });
+    const [selectedFilters, setSelectedFilters] = useState<string[]>([
+        ...queryFilters,
+    ]);
+    const [open, setOpen] = useState(false);
+
+    const handleFilterChange = (filter: string) => {
+        setSelectedFilters((prev) =>
+            prev.includes(filter)
+                ? prev.filter((f) => f !== filter)
+                : [...prev, filter],
+        );
+    };
+
+    const handleReset = () => setSelectedFilters([]);
+
+    const handleSave = () => {
+        setQueryFilters(selectedFilters);
+        setOpen(false);
+    };
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger>
+                <Image
+                    src="/icons/filter.svg"
+                    alt="Filter"
+                    width={12}
+                    height={12}
+                />
+            </PopoverTrigger>
+            <PopoverContent
+                className="w-56 pt-0 pb-0 px-0 rounded-xl"
+                side="bottom"
+            >
+                <div className="max-h-56 overflow-y-auto">
+                    {filterOptions.map((filter) => (
+                        <div
+                            key={filter}
+                            className={cn(
+                                "flex items-center space-x-2 px-2 py-2.5",
+                                selectedFilters.includes(filter) &&
+                                    "bg-brand/5",
+                            )}
+                        >
+                            <Checkbox
+                                id={filter}
+                                checked={selectedFilters.includes(filter)}
+                                onCheckedChange={() =>
+                                    handleFilterChange(filter)
+                                }
+                                className={cn(
+                                    "border border-gray-300 text-white data-[state=checked]:bg-brand data-[state=checked]:border-none",
+                                )}
+                            />
+                            <label
+                                htmlFor={filter}
+                                className={cn(
+                                    "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+                                    selectedFilters.includes(filter) &&
+                                        "text-brand/90",
+                                )}
+                            >
+                                {filter}
+                            </label>
+                        </div>
+                    ))}
+                </div>
+                <div className="flex justify-between px-2 py-2 border-t">
+                    <Button variant="ghost" size="sm" onClick={handleReset}>
+                        Reset
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        className="bg-brand text-white hover:bg-brand/80"
+                        onClick={handleSave}
+                    >
+                        Save
+                    </Button>
+                </div>
+            </PopoverContent>
+        </Popover>
+    );
+};
+
+export default FilterPopover;

--- a/components/tables/infrastructureTable.tsx
+++ b/components/tables/infrastructureTable.tsx
@@ -48,7 +48,14 @@ const InfrastructureImage = ({
 };
 
 const InfrastructureTable = ({ data, headers }: Props) => {
-    const [filter, setFilter] = useQueryState("filter", { defaultValue : "Mainnet" });
+    const [status, setStatus] = useQueryState("status", {
+        defaultValue: "Mainnet",
+    });
+    const [types] = useQueryState<string[]>("type", {
+        defaultValue: [],
+        parse: (value) => value.split(",").filter(Boolean),
+        serialize: (value) => value.join(","),
+    });
 
     const [sortedData, setSortedData] = useState(data);
     const [mobileActiveTab, setMobileActiveTab] = useState<TableTabKey>("Type");
@@ -56,6 +63,16 @@ const InfrastructureTable = ({ data, headers }: Props) => {
     useEffect(() => {
         handleSort("Name", true);
     }, []);
+
+    useEffect(() => {
+        if (types.length > 0) {
+            setSortedData(
+                data.filter((item) => types.includes(item.infrastructureType)),
+            );
+        } else {
+            setSortedData(data);
+        }
+    }, [types, data]);
 
     const handleSort = (header: string, ascending: boolean) => {
         const sorted = [...sortedData].sort((a, b) => {
@@ -96,12 +113,12 @@ const InfrastructureTable = ({ data, headers }: Props) => {
     };
 
     const handleFilter = (header: string, value: string) => {
-        setFilter(value as "Mainnet" | "Testnet" | "All");
+        setStatus(value as "Mainnet" | "Testnet" | "All");
     };
 
     const filteredData = sortedData.filter((item) => {
-        if (filter === "Mainnet") return item.live === "Mainnet";
-        if (filter === "Testnet") return item.live !== "Mainnet";
+        if (status === "Mainnet") return item.live === "Mainnet";
+        if (status === "Testnet") return item.live !== "Mainnet";
         return true;
     });
 
@@ -119,15 +136,15 @@ const InfrastructureTable = ({ data, headers }: Props) => {
                 <div className="justify-start items-start gap-4 inline-flex">
                     <div
                         className={`h-[30px] px-4 py-[5px] rounded-full border-2 justify-center items-center gap-1.5 flex cursor-pointer ${
-                            filter === "Mainnet"
+                            status === "Mainnet"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("Mainnet")}
+                        onClick={() => setStatus("Mainnet")}
                     >
                         <div
                             className={`text-center text-sm font-medium leading-tight ${
-                                filter === "Mainnet"
+                                status === "Mainnet"
                                     ? "text-orange-600"
                                     : "text-slate-600"
                             }`}
@@ -137,16 +154,16 @@ const InfrastructureTable = ({ data, headers }: Props) => {
                     </div>
                     <div
                         className={`h-[30px] rounded-full border-2 justify-center items-center gap-1 flex cursor-pointer ${
-                            filter === "Testnet"
+                            status === "Testnet"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("Testnet")}
+                        onClick={() => setStatus("Testnet")}
                     >
                         <div className="grow shrink basis-0 h-[30px] px-4 py-[5px] justify-center items-center gap-1.5 flex">
                             <div
                                 className={`text-center text-sm font-medium leading-tight ${
-                                    filter === "Testnet"
+                                    status === "Testnet"
                                         ? "text-orange-600"
                                         : "text-slate-600"
                                 }`}
@@ -157,16 +174,16 @@ const InfrastructureTable = ({ data, headers }: Props) => {
                     </div>
                     <div
                         className={`h-[30px] rounded-full border-2 justify-center items-center gap-1 flex cursor-pointer ${
-                            filter === "All"
+                            status === "All"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("All")}
+                        onClick={() => setStatus("All")}
                     >
                         <div className="grow shrink basis-0 h-[30px] px-4 py-[5px] justify-center items-center gap-1.5 flex">
                             <div
                                 className={`text-center text-sm font-medium leading-tight ${
-                                    filter === "All"
+                                    status === "All"
                                         ? "text-orange-600"
                                         : "text-slate-600"
                                 }`}

--- a/components/tables/layerTableAll.tsx
+++ b/components/tables/layerTableAll.tsx
@@ -47,7 +47,14 @@ const LayerImage = ({ src, title }: { src: string; title: string }) => {
 };
 
 const LayerTableAll = ({ data, headers }: Props) => {
-    const [filter, setFilter] = useQueryState("filter", { defaultValue : "Mainnet" });
+    const [status, setStatus] = useQueryState("status", {
+        defaultValue: "Mainnet",
+    });
+    const [types] = useQueryState<string[]>("type", {
+        defaultValue: [],
+        parse: (value) => value.split(",").filter(Boolean),
+        serialize: (value) => value.join(","),
+    });
 
     const [sortedData, setSortedData] = useState(data);
     const [mobileActiveTab, setMobileActiveTab] = useState<TableTabKey>("Risk");
@@ -55,6 +62,16 @@ const LayerTableAll = ({ data, headers }: Props) => {
     useEffect(() => {
         handleSort("Name", true);
     }, []);
+
+    useEffect(() => {
+        if (types.length > 0) {
+            setSortedData(
+                data.filter((item) => types.includes(item.layerType)),
+            );
+        } else {
+            setSortedData(data);
+        }
+    }, [types]);
 
     const handleSort = (header: string, ascending: boolean) => {
         const sorted = [...sortedData].sort((a, b) => {
@@ -94,12 +111,12 @@ const LayerTableAll = ({ data, headers }: Props) => {
     };
 
     const handleFilter = (header: string, value: string) => {
-        setFilter(value as "Mainnet" | "Testnet" | "All");
+        setStatus(value as "Mainnet" | "Testnet" | "All");
     };
 
     const filteredData = sortedData.filter((item) => {
-        if (filter === "Mainnet") return item.live === "Mainnet";
-        if (filter === "Testnet") return item.live !== "Mainnet";
+        if (status === "Mainnet") return item.live === "Mainnet";
+        if (status === "Testnet") return item.live !== "Mainnet";
         return true;
     });
 
@@ -117,15 +134,15 @@ const LayerTableAll = ({ data, headers }: Props) => {
                 <div className="justify-start items-start gap-4 inline-flex">
                     <div
                         className={`h-[30px] px-4 py-[5px] rounded-full border-2 justify-center items-center gap-1.5 flex cursor-pointer ${
-                            filter === "Mainnet"
+                            status === "Mainnet"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("Mainnet")}
+                        onClick={() => setStatus("Mainnet")}
                     >
                         <div
                             className={`text-center text-sm font-medium leading-tight ${
-                                filter === "Mainnet"
+                                status === "Mainnet"
                                     ? "text-orange-600"
                                     : "text-slate-600"
                             }`}
@@ -135,16 +152,16 @@ const LayerTableAll = ({ data, headers }: Props) => {
                     </div>
                     <div
                         className={`h-[30px] rounded-full border-2 justify-center items-center gap-1 flex cursor-pointer ${
-                            filter === "Testnet"
+                            status === "Testnet"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("Testnet")}
+                        onClick={() => setStatus("Testnet")}
                     >
                         <div className="grow shrink basis-0 h-[30px] px-4 py-[5px] justify-center items-center gap-1.5 flex">
                             <div
                                 className={`text-center text-sm font-medium leading-tight ${
-                                    filter === "Testnet"
+                                    status === "Testnet"
                                         ? "text-orange-600"
                                         : "text-slate-600"
                                 }`}
@@ -155,16 +172,16 @@ const LayerTableAll = ({ data, headers }: Props) => {
                     </div>
                     <div
                         className={`h-[30px] rounded-full border-2 justify-center items-center gap-1 flex cursor-pointer ${
-                            filter === "All"
+                            status === "All"
                                 ? "bg-white border-orange-600"
                                 : "border-slate-300"
                         }`}
-                        onClick={() => setFilter("All")}
+                        onClick={() => setStatus("All")}
                     >
                         <div className="grow shrink basis-0 h-[30px] px-4 py-[5px] justify-center items-center gap-1.5 flex">
                             <div
                                 className={`text-center text-sm font-medium leading-tight ${
-                                    filter === "All"
+                                    status === "All"
                                         ? "text-orange-600"
                                         : "text-slate-600"
                                 }`}

--- a/components/tables/tableHeader.tsx
+++ b/components/tables/tableHeader.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import Image from "next/image";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import FilterPopover from "./filter-popover";
 
 interface TableHeaderProps {
     headers: {
@@ -51,59 +53,9 @@ const TableHeader: React.FC<TableHeaderProps> = ({
                             <div className="relative flex items-center">
                                 {header.filterOptions && (
                                     <div className="relative mr-2">
-                                        <Image
-                                            src="/icons/filter.svg"
-                                            alt="Filter"
-                                            width={12}
-                                            height={12}
-                                            className="cursor-pointer"
-                                            onClick={() =>
-                                                toggleFilterDropdown(
-                                                    header.name,
-                                                )
-                                            }
+                                        <FilterPopover
+                                            filters={header.filterOptions}
                                         />
-                                        {filterOpen === header.name && (
-                                            <div className="absolute top-full left-0 mt-2 w-[] bg-white rounded-xl shadow-lg z-50 p-4">
-                                                <div className="h-[204px] flex-col justify-start items-start flex overflow-y-auto">
-                                                    {header.filterOptions.map(
-                                                        (option, idx) => (
-                                                            <div
-                                                                key={idx}
-                                                                className="h-8 px-3 py-[5px] flex items-center gap-2 cursor-pointer hover:bg-gray-100"
-                                                                onClick={() =>
-                                                                    onFilter(
-                                                                        header.name,
-                                                                        option,
-                                                                    )
-                                                                }
-                                                            >
-                                                                <div className="w-4 h-4 bg-white rounded-sm border border-slate-300"></div>
-                                                                <div className="text-slate-600 text-sm font-normal leading-tight">
-                                                                    {option}
-                                                                </div>
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </div>
-                                                <div className="flex justify-between items-center p-2 border-t border-indigo-100">
-                                                    <button
-                                                        className="text-orange-600 text-sm font-normal"
-                                                        onClick={() =>
-                                                            onFilter(
-                                                                header.name,
-                                                                "",
-                                                            )
-                                                        }
-                                                    >
-                                                        Reset
-                                                    </button>
-                                                    <button className="bg-orange-600 text-neutral-100 text-sm font-medium rounded-full px-3 py-1">
-                                                        Save
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        )}
                                     </div>
                                 )}
                                 {header.showSorting && (

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    {
+        variants: {
+            variant: {
+                default:
+                    "bg-primary text-primary-foreground hover:bg-primary/90",
+                destructive:
+                    "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+                outline:
+                    "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+                secondary:
+                    "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+                ghost: "hover:bg-accent hover:text-accent-foreground",
+                link: "text-primary underline-offset-4 hover:underline",
+            },
+            size: {
+                default: "h-10 px-4 py-2",
+                sm: "h-9 rounded-md px-3",
+                lg: "h-11 rounded-md px-8",
+                icon: "h-10 w-10",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    },
+);
+
+export interface ButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+        VariantProps<typeof buttonVariants> {
+    asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ className, variant, size, asChild = false, ...props }, ref) => {
+        const Comp = asChild ? Slot : "button";
+        return (
+            <Comp
+                className={cn(buttonVariants({ variant, size, className }))}
+                ref={ref}
+                {...props}
+            />
+        );
+    },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<
+    React.ElementRef<typeof CheckboxPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+    <CheckboxPrimitive.Root
+        ref={ref}
+        className={cn(
+            "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+            className,
+        )}
+        {...props}
+    >
+        <CheckboxPrimitive.Indicator
+            className={cn("flex items-center justify-center text-current")}
+        >
+            <Check className="h-4 w-4" />
+        </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+    React.ElementRef<typeof PopoverPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+    <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+            ref={ref}
+            align={align}
+            sideOffset={sideOffset}
+            className={cn(
+                "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                className,
+            )}
+            {...props}
+        />
+    </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,27 +8,35 @@
             "name": "bitcoinlayers",
             "version": "1.0.0",
             "dependencies": {
+                "@radix-ui/react-checkbox": "^1.1.1",
+                "@radix-ui/react-popover": "^1.1.1",
+                "@radix-ui/react-slot": "^1.1.0",
                 "@tailwindcss/typography": "^0.5.9",
                 "@types/node": "18.16.1",
                 "@types/react": "18.2.0",
                 "@types/react-dom": "18.2.1",
                 "@vercel/analytics": "^1.0.0",
-                "autoprefixer": "10.4.14",
                 "chart.js": "^4.4.1",
+                "class-variance-authority": "^0.7.0",
+                "clsx": "^2.1.1",
                 "eslint": "8.39.0",
                 "eslint-config-next": "13.3.1",
+                "lucide-react": "^0.436.0",
                 "next": "^13.4.1",
                 "next-themes": "^0.2.1",
                 "nuqs": "^1.17.8",
-                "postcss": "8.4.23",
                 "react": "^18.3.1",
                 "react-device-detect": "^2.2.3",
                 "react-dom": "^18.2.0",
-                "tailwindcss": "3.3.2",
+                "tailwind-merge": "^2.5.2",
+                "tailwindcss-animate": "^1.0.7",
                 "typescript": "5.0.4"
             },
             "devDependencies": {
-                "prettier": "^3.3.0"
+                "autoprefixer": "^10.4.20",
+                "postcss": "^8.4.41",
+                "prettier": "^3.3.0",
+                "tailwindcss": "^3.4.10"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -112,6 +120,44 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+            "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.7"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.6.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+            "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/core": "^1.6.0",
+                "@floating-ui/utils": "^0.2.7"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+            "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+            "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
+            "license": "MIT"
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -474,6 +520,461 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@radix-ui/primitive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+            "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==",
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/react-arrow": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
+            "integrity": "sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-checkbox": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.1.tgz",
+            "integrity": "sha512-0i/EKJ222Afa1FE0C6pNJxDq1itzcl3HChE9DwskA4th4KRse8ojx8a1nVcOjwJdbpDLcz7uol77yYnQNMHdKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-presence": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "@radix-ui/react-use-previous": "1.1.0",
+                "@radix-ui/react-use-size": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+            "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+            "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dismissable-layer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+            "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0",
+                "@radix-ui/react-use-escape-keydown": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-guards": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+            "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-scope": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+            "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-id": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+            "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.1.tgz",
+            "integrity": "sha512-3y1A3isulwnWhvTTwmIreiB8CF4L+qRjZnK1wYLO7pplddzXKby/GnZ2M7OZY3qgnl6p9AodUIHRYGXNah8Y7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-dismissable-layer": "1.1.0",
+                "@radix-ui/react-focus-guards": "1.1.0",
+                "@radix-ui/react-focus-scope": "1.1.0",
+                "@radix-ui/react-id": "1.1.0",
+                "@radix-ui/react-popper": "1.2.0",
+                "@radix-ui/react-portal": "1.1.1",
+                "@radix-ui/react-presence": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-slot": "1.1.0",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "aria-hidden": "^1.1.1",
+                "react-remove-scroll": "2.5.7"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popper": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
+            "integrity": "sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/react-dom": "^2.0.0",
+                "@radix-ui/react-arrow": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0",
+                "@radix-ui/react-use-rect": "1.1.0",
+                "@radix-ui/react-use-size": "1.1.0",
+                "@radix-ui/rect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-portal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+            "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-presence": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+            "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+            "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+            "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+            "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+            "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-escape-keydown": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+            "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+            "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-previous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+            "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-rect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+            "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/rect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-size": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+            "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/rect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+            "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+            "license": "MIT"
+        },
         "node_modules/@rushstack/eslint-patch": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
@@ -738,6 +1239,18 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
+        "node_modules/aria-hidden": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+            "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/aria-query": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -904,9 +1417,10 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.14",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-            "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+            "version": "10.4.20",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+            "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -915,14 +1429,19 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.21.5",
-                "caniuse-lite": "^1.0.30001464",
-                "fraction.js": "^4.2.0",
+                "browserslist": "^4.23.3",
+                "caniuse-lite": "^1.0.30001646",
+                "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "bin": {
@@ -999,9 +1518,10 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -1016,11 +1536,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1075,9 +1596,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001589",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-            "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+            "version": "1.0.30001653",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+            "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1091,7 +1612,8 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "license": "CC-BY-4.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -1142,10 +1664,40 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/class-variance-authority": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+            "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "clsx": "2.0.0"
+            },
+            "funding": {
+                "url": "https://joebell.co.uk"
+            }
+        },
+        "node_modules/class-variance-authority/node_modules/clsx": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+            "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/client-only": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -1271,6 +1823,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+            "license": "MIT"
+        },
         "node_modules/didyoumean": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1309,9 +1867,11 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.681",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.681.tgz",
-            "integrity": "sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg=="
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -1474,6 +2034,8 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
             "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -2008,6 +2570,7 @@
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
             "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "dev": true,
             "engines": {
                 "node": "*"
             },
@@ -2083,6 +2646,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/get-symbol-description": {
@@ -2351,6 +2923,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/is-array-buffer": {
@@ -2878,6 +3459,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lucide-react": {
+            "version": "0.436.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.436.0.tgz",
+            "integrity": "sha512-N292bIxoqm1aObAg0MzFtvhYwgQE6qnIOWx/GLj5ONgcTPH6N0fD9bVq/GfdeC9ZORBXozt/XeEKDpiB3x3vlQ==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+            }
+        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3064,9 +3654,11 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -3080,6 +3672,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3338,9 +3931,10 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -3378,9 +3972,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-            "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+            "version": "8.4.41",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3395,10 +3989,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "nanoid": "^3.3.7",
+                "picocolors": "^1.0.1",
+                "source-map-js": "^1.2.0"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -3631,6 +4226,76 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-remove-scroll": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+            "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+            "license": "MIT",
+            "dependencies": {
+                "react-remove-scroll-bar": "^2.3.4",
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.0",
+                "use-sidecar": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-remove-scroll-bar": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+            "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+            "license": "MIT",
+            "dependencies": {
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-style-singleton": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+            "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+            "license": "MIT",
+            "dependencies": {
+                "get-nonce": "^1.0.0",
+                "invariant": "^2.2.4",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
@@ -3916,9 +4581,10 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4179,20 +4845,31 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/tailwind-merge": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.2.tgz",
+            "integrity": "sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
+        },
         "node_modules/tailwindcss": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-            "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+            "version": "3.4.10",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.10.tgz",
+            "integrity": "sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==",
+            "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
                 "chokidar": "^3.5.3",
                 "didyoumean": "^1.2.2",
                 "dlv": "^1.1.3",
-                "fast-glob": "^3.2.12",
+                "fast-glob": "^3.3.0",
                 "glob-parent": "^6.0.2",
                 "is-glob": "^4.0.3",
-                "jiti": "^1.18.2",
+                "jiti": "^1.21.0",
                 "lilconfig": "^2.1.0",
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
@@ -4204,7 +4881,6 @@
                 "postcss-load-config": "^4.0.1",
                 "postcss-nested": "^6.0.1",
                 "postcss-selector-parser": "^6.0.11",
-                "postcss-value-parser": "^4.2.0",
                 "resolve": "^1.22.2",
                 "sucrase": "^3.32.0"
             },
@@ -4214,6 +4890,15 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tailwindcss-animate": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+            "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "tailwindcss": ">=3.0.0 || insiders"
             }
         },
         "node_modules/tailwindcss/node_modules/glob-parent": {
@@ -4451,9 +5136,10 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4468,9 +5154,10 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -4485,6 +5172,49 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-callback-ref": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+            "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-sidecar": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+            "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+            "license": "MIT",
+            "dependencies": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/util-deprecate": {
@@ -4680,6 +5410,36 @@
             "version": "8.39.0",
             "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
             "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng=="
+        },
+        "@floating-ui/core": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+            "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+            "requires": {
+                "@floating-ui/utils": "^0.2.7"
+            }
+        },
+        "@floating-ui/dom": {
+            "version": "1.6.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+            "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+            "requires": {
+                "@floating-ui/core": "^1.6.0",
+                "@floating-ui/utils": "^0.2.7"
+            }
+        },
+        "@floating-ui/react-dom": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+            "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+            "requires": {
+                "@floating-ui/dom": "^1.0.0"
+            }
+        },
+        "@floating-ui/utils": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+            "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -4896,6 +5656,210 @@
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "optional": true
         },
+        "@radix-ui/primitive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+            "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+        },
+        "@radix-ui/react-arrow": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
+            "integrity": "sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==",
+            "requires": {
+                "@radix-ui/react-primitive": "2.0.0"
+            }
+        },
+        "@radix-ui/react-checkbox": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.1.tgz",
+            "integrity": "sha512-0i/EKJ222Afa1FE0C6pNJxDq1itzcl3HChE9DwskA4th4KRse8ojx8a1nVcOjwJdbpDLcz7uol77yYnQNMHdKw==",
+            "requires": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-presence": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "@radix-ui/react-use-previous": "1.1.0",
+                "@radix-ui/react-use-size": "1.1.0"
+            }
+        },
+        "@radix-ui/react-compose-refs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+            "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+            "requires": {}
+        },
+        "@radix-ui/react-context": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+            "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+            "requires": {}
+        },
+        "@radix-ui/react-dismissable-layer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+            "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+            "requires": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0",
+                "@radix-ui/react-use-escape-keydown": "1.1.0"
+            }
+        },
+        "@radix-ui/react-focus-guards": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+            "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+            "requires": {}
+        },
+        "@radix-ui/react-focus-scope": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+            "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+            "requires": {
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            }
+        },
+        "@radix-ui/react-id": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+            "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+            "requires": {
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            }
+        },
+        "@radix-ui/react-popover": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.1.tgz",
+            "integrity": "sha512-3y1A3isulwnWhvTTwmIreiB8CF4L+qRjZnK1wYLO7pplddzXKby/GnZ2M7OZY3qgnl6p9AodUIHRYGXNah8Y7g==",
+            "requires": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-dismissable-layer": "1.1.0",
+                "@radix-ui/react-focus-guards": "1.1.0",
+                "@radix-ui/react-focus-scope": "1.1.0",
+                "@radix-ui/react-id": "1.1.0",
+                "@radix-ui/react-popper": "1.2.0",
+                "@radix-ui/react-portal": "1.1.1",
+                "@radix-ui/react-presence": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-slot": "1.1.0",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "aria-hidden": "^1.1.1",
+                "react-remove-scroll": "2.5.7"
+            }
+        },
+        "@radix-ui/react-popper": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
+            "integrity": "sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==",
+            "requires": {
+                "@floating-ui/react-dom": "^2.0.0",
+                "@radix-ui/react-arrow": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0",
+                "@radix-ui/react-use-rect": "1.1.0",
+                "@radix-ui/react-use-size": "1.1.0",
+                "@radix-ui/rect": "1.1.0"
+            }
+        },
+        "@radix-ui/react-portal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+            "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+            "requires": {
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            }
+        },
+        "@radix-ui/react-presence": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+            "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+            "requires": {
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            }
+        },
+        "@radix-ui/react-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+            "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+            "requires": {
+                "@radix-ui/react-slot": "1.1.0"
+            }
+        },
+        "@radix-ui/react-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+            "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+            "requires": {
+                "@radix-ui/react-compose-refs": "1.1.0"
+            }
+        },
+        "@radix-ui/react-use-callback-ref": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+            "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+            "requires": {}
+        },
+        "@radix-ui/react-use-controllable-state": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+            "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+            "requires": {
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            }
+        },
+        "@radix-ui/react-use-escape-keydown": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+            "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+            "requires": {
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            }
+        },
+        "@radix-ui/react-use-layout-effect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+            "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+            "requires": {}
+        },
+        "@radix-ui/react-use-previous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+            "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+            "requires": {}
+        },
+        "@radix-ui/react-use-rect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+            "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+            "requires": {
+                "@radix-ui/rect": "1.1.0"
+            }
+        },
+        "@radix-ui/react-use-size": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+            "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+            "requires": {
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            }
+        },
+        "@radix-ui/rect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+            "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
+        },
         "@rushstack/eslint-patch": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
@@ -5073,6 +6037,14 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
+        "aria-hidden": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+            "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+            "requires": {
+                "tslib": "^2.0.0"
+            }
+        },
         "aria-query": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -5194,15 +6166,16 @@
             }
         },
         "autoprefixer": {
-            "version": "10.4.14",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-            "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+            "version": "10.4.20",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+            "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+            "dev": true,
             "requires": {
-                "browserslist": "^4.21.5",
-                "caniuse-lite": "^1.0.30001464",
-                "fraction.js": "^4.2.0",
+                "browserslist": "^4.23.3",
+                "caniuse-lite": "^1.0.30001646",
+                "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
@@ -5255,14 +6228,15 @@
             }
         },
         "browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+            "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             }
         },
         "busboy": {
@@ -5296,9 +6270,9 @@
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
         },
         "caniuse-lite": {
-            "version": "1.0.30001589",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-            "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg=="
+            "version": "1.0.30001653",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+            "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw=="
         },
         "chalk": {
             "version": "4.1.2",
@@ -5332,10 +6306,30 @@
                 "readdirp": "~3.6.0"
             }
         },
+        "class-variance-authority": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+            "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+            "requires": {
+                "clsx": "2.0.0"
+            },
+            "dependencies": {
+                "clsx": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+                    "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+                }
+            }
+        },
         "client-only": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+        },
+        "clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         },
         "color-convert": {
             "version": "2.0.1",
@@ -5423,6 +6417,11 @@
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
         },
+        "detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+        },
         "didyoumean": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -5455,9 +6454,10 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "electron-to-chromium": {
-            "version": "1.4.681",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.681.tgz",
-            "integrity": "sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg=="
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+            "dev": true
         },
         "emoji-regex": {
             "version": "9.2.2",
@@ -5592,7 +6592,8 @@
         "escalade": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "4.0.0",
@@ -5993,7 +6994,8 @@
         "fraction.js": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="
+            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -6038,6 +7040,11 @@
                 "has-symbols": "^1.0.3",
                 "hasown": "^2.0.0"
             }
+        },
+        "get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
         },
         "get-symbol-description": {
             "version": "1.0.2",
@@ -6217,6 +7224,14 @@
                 "es-errors": "^1.3.0",
                 "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
+            }
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "requires": {
+                "loose-envify": "^1.0.0"
             }
         },
         "is-array-buffer": {
@@ -6579,6 +7594,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lucide-react": {
+            "version": "0.436.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.436.0.tgz",
+            "integrity": "sha512-N292bIxoqm1aObAg0MzFtvhYwgQE6qnIOWx/GLj5ONgcTPH6N0fD9bVq/GfdeC9ZORBXozt/XeEKDpiB3x3vlQ==",
+            "requires": {}
+        },
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6688,9 +7709,10 @@
             "requires": {}
         },
         "node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "dev": true
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -6700,7 +7722,8 @@
         "normalize-range": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
+            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+            "dev": true
         },
         "nuqs": {
             "version": "1.17.8",
@@ -6879,9 +7902,9 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
         },
         "picomatch": {
             "version": "2.3.1",
@@ -6904,13 +7927,13 @@
             "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
         },
         "postcss": {
-            "version": "8.4.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-            "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+            "version": "8.4.41",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
             "requires": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "nanoid": "^3.3.7",
+                "picocolors": "^1.0.1",
+                "source-map-js": "^1.2.0"
             }
         },
         "postcss-import": {
@@ -7040,6 +8063,37 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-remove-scroll": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+            "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+            "requires": {
+                "react-remove-scroll-bar": "^2.3.4",
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.0",
+                "use-sidecar": "^1.1.2"
+            }
+        },
+        "react-remove-scroll-bar": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+            "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+            "requires": {
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.0.0"
+            }
+        },
+        "react-style-singleton": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+            "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+            "requires": {
+                "get-nonce": "^1.0.0",
+                "invariant": "^2.2.4",
+                "tslib": "^2.0.0"
+            }
         },
         "read-cache": {
             "version": "1.0.0",
@@ -7229,9 +8283,9 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
         },
         "streamsearch": {
             "version": "1.1.0",
@@ -7409,20 +8463,25 @@
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
         },
+        "tailwind-merge": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.2.tgz",
+            "integrity": "sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg=="
+        },
         "tailwindcss": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-            "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+            "version": "3.4.10",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.10.tgz",
+            "integrity": "sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==",
             "requires": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
                 "chokidar": "^3.5.3",
                 "didyoumean": "^1.2.2",
                 "dlv": "^1.1.3",
-                "fast-glob": "^3.2.12",
+                "fast-glob": "^3.3.0",
                 "glob-parent": "^6.0.2",
                 "is-glob": "^4.0.3",
-                "jiti": "^1.18.2",
+                "jiti": "^1.21.0",
                 "lilconfig": "^2.1.0",
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
@@ -7434,7 +8493,6 @@
                 "postcss-load-config": "^4.0.1",
                 "postcss-nested": "^6.0.1",
                 "postcss-selector-parser": "^6.0.11",
-                "postcss-value-parser": "^4.2.0",
                 "resolve": "^1.22.2",
                 "sucrase": "^3.32.0"
             },
@@ -7457,6 +8515,12 @@
                     }
                 }
             }
+        },
+        "tailwindcss-animate": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+            "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+            "requires": {}
         },
         "tapable": {
             "version": "2.2.1",
@@ -7606,12 +8670,13 @@
             }
         },
         "update-browserslist-db": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+            "dev": true,
             "requires": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
             }
         },
         "uri-js": {
@@ -7620,6 +8685,23 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "requires": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "use-callback-ref": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+            "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+            "requires": {
+                "tslib": "^2.0.0"
+            }
+        },
+        "use-sidecar": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+            "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+            "requires": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
             }
         },
         "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -11,26 +11,34 @@
         "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
     },
     "dependencies": {
+        "@radix-ui/react-checkbox": "^1.1.1",
+        "@radix-ui/react-popover": "^1.1.1",
+        "@radix-ui/react-slot": "^1.1.0",
         "@tailwindcss/typography": "^0.5.9",
         "@types/node": "18.16.1",
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.1",
         "@vercel/analytics": "^1.0.0",
-        "autoprefixer": "10.4.14",
         "chart.js": "^4.4.1",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
         "eslint": "8.39.0",
         "eslint-config-next": "13.3.1",
+        "lucide-react": "^0.436.0",
         "next": "^13.4.1",
         "next-themes": "^0.2.1",
         "nuqs": "^1.17.8",
-        "postcss": "8.4.23",
         "react": "^18.3.1",
         "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
-        "tailwindcss": "3.3.2",
+        "tailwind-merge": "^2.5.2",
+        "tailwindcss-animate": "^1.0.7",
         "typescript": "5.0.4"
     },
     "devDependencies": {
-        "prettier": "^3.3.0"
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.41",
+        "prettier": "^3.3.0",
+        "tailwindcss": "^3.4.10"
     }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,54 +1,88 @@
-/** @type {import('tailwindcss').Config} */
+import type { Config } from "tailwindcss";
 
-module.exports = {
+const config = {
+    darkMode: ["class"],
     content: [
-        "./app/**/*.{ts,tsx}",
+        "./pages/**/*.{ts,tsx}",
         "./components/**/*.{ts,tsx}",
+        "./app/**/*.{ts,tsx}",
+        "./src/**/*.{ts,tsx}",
         "./content/**/*.{md,mdx}",
     ],
-    darkMode: ["class"],
+    prefix: "",
     theme: {
+        container: {
+            center: true,
+            padding: "2rem",
+            screens: {
+                "2xl": "1400px",
+            },
+        },
         extend: {
             colors: {
+                border: "hsl(var(--border))",
+                input: "hsl(var(--input))",
+                ring: "hsl(var(--ring))",
+                background: "hsl(var(--background))",
+                foreground: "hsl(var(--foreground))",
+                // primary: {
+                //   DEFAULT: "hsl(var(--primary))",
+                //   foreground: "hsl(var(--primary-foreground))",
+                // },
+                secondary: {
+                    DEFAULT: "hsl(var(--secondary))",
+                    foreground: "hsl(var(--secondary-foreground))",
+                },
+                destructive: {
+                    DEFAULT: "hsl(var(--destructive))",
+                    foreground: "hsl(var(--destructive-foreground))",
+                },
+                muted: {
+                    DEFAULT: "hsl(var(--muted))",
+                    foreground: "hsl(var(--muted-foreground))",
+                },
+                accent: {
+                    DEFAULT: "hsl(var(--accent))",
+                    foreground: "hsl(var(--accent-foreground))",
+                },
+                popover: {
+                    DEFAULT: "hsl(var(--popover))",
+                    foreground: "hsl(var(--popover-foreground))",
+                },
+                card: {
+                    DEFAULT: "hsl(var(--card))",
+                    foreground: "hsl(var(--card-foreground))",
+                },
+                // Colors from the JavaScript file
                 primary: "#121212",
                 bitcoin: "#FF9900",
                 low: "#7EFF00",
                 medium: "#FFC21B",
                 high: "#EC0B43",
                 critical: "#A50F11",
-
                 lightsecondary: "#e5ebeb",
                 lighttertiary: "#CECECA",
                 lighttableheader: "#736F72",
-
                 text_table_row: "#363534",
                 text_table_header: "#0A0D12",
                 table_header: "#F5F8FD",
-
-                //figma
                 brand: "#FE4F18",
                 brand_fill: "#F4F7FA",
                 brand_neutral: "3C3D41",
-
                 bg_primary: "#FDFDFD",
                 bg_secondary: "F5F8FD",
                 bg_tertiary: "FFFFFF",
-
-                //general colors
                 icon_primary: "#292929",
                 icon_secondary: "#434D65",
                 icon_tertiary: "#C9D0D8",
                 icon_quaternary: "#F4F7FA",
-
                 state_default: "#FDFDFD",
                 state_hover: "#F5F8FD",
                 state_brand: "#FFF4ED",
-
                 stroke_brand: "#FE4F18",
                 stroke_primary: "#767B8F",
                 stroke_secondary: "#D3DDE8",
                 stroke_tertiary: "#E1EAF8",
-
                 text_header: "#292929",
                 text_primary: "#434D65",
                 text_secondary: "#767B8F",
@@ -116,6 +150,9 @@ module.exports = {
                 "Backdrop Blur/backdrop-blur-3xl": "",
             },
             borderRadius: {
+                lg: "var(--radius)",
+                md: "calc(var(--radius) - 2px)",
+                sm: "calc(var(--radius) - 4px)",
                 "rounded-0": "0rem",
                 "rounded-1": "0.046875rem",
                 "rounded-2": "0.05181884765625rem",
@@ -145,7 +182,26 @@ module.exports = {
                 "rounded-26": "4rem",
                 "rounded-27": "62.4375rem",
             },
+            keyframes: {
+                "accordion-down": {
+                    from: { height: "0" },
+                    to: { height: "var(--radix-accordion-content-height)" },
+                },
+                "accordion-up": {
+                    from: { height: "var(--radix-accordion-content-height)" },
+                    to: { height: "0" },
+                },
+            },
+            animation: {
+                "accordion-down": "accordion-down 0.2s ease-out",
+                "accordion-up": "accordion-up 0.2s ease-out",
+            },
         },
     },
-    plugins: [require("@tailwindcss/typography")],
-};
+    plugins: [
+        require("tailwindcss-animate"),
+        require("@tailwindcss/typography"),
+    ],
+} satisfies Config;
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2015",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,

--- a/util/layer_index.tsx
+++ b/util/layer_index.tsx
@@ -46,7 +46,6 @@ import bitcoinosJson from "../content/layers/bitcoinos.json";
 import satoshivmJson from "../content/layers/satoshivm.json";
 import bouncebitJson from "../content/layers/bouncebit.json";
 
-
 // @ts-ignore
 const core: Layer = coreJson as Layer;
 const internetcomputer: Layer = internetcomputerJson as Layer;


### PR DESCRIPTION
Notes:

This PR introduces shadcn UI components. These are customizable components that work out of the box when installed.

globals.css and tailwind config have been updated to reconcile old and new.

Type column filters in tables are added as query params when "Save" button is clicked in popover. These will persist in navigation history and can be used as shareable links to show specific table data.

Setup for Layers, Infra, and BTC only tables.