### PR TITLE
Add realtime TVL to layers table

### DIFF
--- a/components/charts/layers-tvl-chart.tsx
+++ b/components/charts/layers-tvl-chart.tsx
@@ -40,7 +40,7 @@ export default function LayersTVLChart() {
         defaultValue: "3mo",
     });
 
-    const { data } = useGetBalances()
+    const { data } = useGetBalances();
 
     const layers =
         chartType === "combined"

--- a/components/charts/layers-tvl-chart.tsx
+++ b/components/charts/layers-tvl-chart.tsx
@@ -16,8 +16,6 @@ import {
     ChartTooltipContent,
 } from "@/components/ui/chart";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { useQuery } from "@tanstack/react-query";
-import { fetcher } from "@/util/fetcher";
 import {
     Select,
     SelectContent,
@@ -27,14 +25,7 @@ import {
 } from "@/components/ui/select";
 import { useQueryState } from "nuqs";
 import { useMemo, useCallback } from "react";
-
-interface Balance {
-    amount: number;
-    date: string;
-    identifier: string;
-    layer_name: string;
-    token_name: string;
-}
+import useGetBalances from "@/hooks/use-get-balances";
 
 interface ProcessedData {
     date: string;
@@ -49,11 +40,7 @@ export default function LayersTVLChart() {
         defaultValue: "3mo",
     });
 
-    const { data } = useQuery<Balance[]>({
-        queryKey: ["get_balances"],
-        queryFn: () =>
-            fetcher(`${process.env.NEXT_PUBLIC_API_URL}/get_balances`),
-    });
+    const { data } = useGetBalances()
 
     const layers =
         chartType === "combined"
@@ -62,7 +49,7 @@ export default function LayersTVLChart() {
 
     const processedData = useMemo(() => {
         if (!data) return [];
-        return data.reduce((acc: ProcessedData[], item: Balance) => {
+        return data.reduce((acc: ProcessedData[], item) => {
             const itemDateUTC = item.date;
             const existingEntry = acc.find(
                 (entry) => entry.date === itemDateUTC,

--- a/components/charts/project-tvl-chart.tsx
+++ b/components/charts/project-tvl-chart.tsx
@@ -9,8 +9,6 @@ import {
     ChartTooltip,
     ChartTooltipContent,
 } from "@/components/ui/chart";
-import { useQuery } from "@tanstack/react-query";
-import { fetcher } from "@/util/fetcher";
 import {
     Select,
     SelectContent,
@@ -21,16 +19,7 @@ import {
 import { useQueryState } from "nuqs";
 import { useCallback, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
-
-interface Balance {
-    amount: number;
-    date: string;
-    identifier: string;
-    layer_name: string;
-    token_name: string;
-    TPS: number;
-    "Fee Revenue": number;
-}
+import useGetBalances from "@/hooks/use-get-balances";
 
 interface ProcessedData {
     date: string;
@@ -48,13 +37,9 @@ export default function ProjectTVLChart() {
         defaultValue: "3mo",
     });
 
-    const { data } = useQuery<Balance[]>({
-        queryKey: [`get_balances?layer_name=ilike.${slug}`],
-        queryFn: () =>
-            fetcher(
-                `${process.env.NEXT_PUBLIC_API_URL}/get_balances?layer_name=ilike.${slug}`,
-            ),
-    });
+    const { data } = useGetBalances({
+        queryString: `?layer_name=ilike.${slug}`
+     })
 
     const tokens = useMemo(
         () =>
@@ -66,7 +51,7 @@ export default function ProjectTVLChart() {
 
     const processedData = useMemo(() => {
         if (!data) return [];
-        return data.reduce((acc: ProcessedData[], item: Balance) => {
+        return data.reduce((acc: ProcessedData[], item) => {
             const itemDateUTC = item.date;
             const existingEntry = acc.find(
                 (entry) => entry.date === itemDateUTC,
@@ -158,12 +143,7 @@ export default function ProjectTVLChart() {
         }, 0);
 
         return {
-            TVL: tvl,
-            TPS: filteredData.reduce((acc, curr) => acc + (curr.TPS || 0), 0),
-            "Fee Rev.": filteredData.reduce(
-                (acc, curr) => acc + (curr["Fee Revenue"] || 0),
-                0,
-            ),
+            TVL: tvl
         };
     }, [data, dateRange, tokens]);
 

--- a/components/charts/project-tvl-chart.tsx
+++ b/components/charts/project-tvl-chart.tsx
@@ -38,8 +38,8 @@ export default function ProjectTVLChart() {
     });
 
     const { data } = useGetBalances({
-        queryString: `?layer_name=ilike.${slug}`
-     })
+        queryString: `?layer_name=ilike.${slug}`,
+    });
 
     const tokens = useMemo(
         () =>
@@ -143,7 +143,7 @@ export default function ProjectTVLChart() {
         }, 0);
 
         return {
-            TVL: tvl
+            TVL: tvl,
         };
     }, [data, dateRange, tokens]);
 

--- a/components/tables/layerTableAll.tsx
+++ b/components/tables/layerTableAll.tsx
@@ -67,21 +67,28 @@ const LayerTableAll = ({ data, headers, showToggleGroup = true }: Props) => {
     });
 
     const { data: balances } = useGetBalances({
-        queryString: `?date=gte.${new Date(Date.now() - 86400000).toDateString()}`
-    })
+        queryString: `?date=gte.${new Date(Date.now() - 86400000).toDateString()}`,
+    });
 
     const organizedBalances = useMemo(() => {
         if (!balances) return {};
 
-        return balances.reduce((acc, balance) => {
-            if (!acc[balance.layer_name] || new Date(balance.date) > new Date(acc[balance.layer_name].date)) {
-                acc[balance.layer_name] = {
-                    amount: balance.amount,
-                    date: balance.date
-                };
-            }
-            return acc;
-        }, {} as Record<string, { amount: number; date: string }>);
+        return balances.reduce(
+            (acc, balance) => {
+                if (
+                    !acc[balance.layer_name] ||
+                    new Date(balance.date) >
+                        new Date(acc[balance.layer_name].date)
+                ) {
+                    acc[balance.layer_name] = {
+                        amount: balance.amount,
+                        date: balance.date,
+                    };
+                }
+                return acc;
+            },
+            {} as Record<string, { amount: number; date: string }>,
+        );
     }, [balances]);
 
     const [mobileActiveTab, setMobileActiveTab] = useState<TableTabKey>("Risk");
@@ -342,8 +349,15 @@ const LayerTableAll = ({ data, headers, showToggleGroup = true }: Props) => {
                                     <td className="lg:px-6 px-4 py-3 lg:py-4 border-r border-stroke_tertiary text_table_important">
                                         <Link href={`/layers/${item.slug}`}>
                                             {item.underReview === "yes" ||
-                                            (Object.keys(organizedBalances).find(key => key.toLowerCase() === item.title.toLowerCase()) === undefined && 
-                                             (item.btcLocked === null || isNaN(item.btcLocked))) ? (
+                                            (Object.keys(
+                                                organizedBalances,
+                                            ).find(
+                                                (key) =>
+                                                    key.toLowerCase() ===
+                                                    item.title.toLowerCase(),
+                                            ) === undefined &&
+                                                (item.btcLocked === null ||
+                                                    isNaN(item.btcLocked))) ? (
                                                 <div className="font-light">
                                                     Under review
                                                 </div>
@@ -351,8 +365,17 @@ const LayerTableAll = ({ data, headers, showToggleGroup = true }: Props) => {
                                                 <div>
                                                     ₿{" "}
                                                     {Number(
-                                                        Object.entries(organizedBalances).find(([key]) => key.toLowerCase().includes(item.title.toLowerCase()))?.[1]?.amount ?? item.btcLocked
-                                                    ).toLocaleString('en-US', {
+                                                        Object.entries(
+                                                            organizedBalances,
+                                                        ).find(([key]) =>
+                                                            key
+                                                                .toLowerCase()
+                                                                .includes(
+                                                                    item.title.toLowerCase(),
+                                                                ),
+                                                        )?.[1]?.amount ??
+                                                            item.btcLocked,
+                                                    ).toLocaleString("en-US", {
                                                         minimumFractionDigits: 0,
                                                         maximumFractionDigits: 0,
                                                     })}

--- a/content/layers/bitlayer.json
+++ b/content/layers/bitlayer.json
@@ -96,7 +96,6 @@
                 {
                     "title": "Bridge participants",
                     "content": "Coinbase and Sinohope are the two institutions that have been said to be participating in securing BitLayer's official bridge. Limited information around the current two-way peg construction is available."
-                    
                 },
                 {
                     "title": "BitVM exploration",

--- a/hooks/use-get-balances.tsx
+++ b/hooks/use-get-balances.tsx
@@ -1,0 +1,25 @@
+import { fetcher } from "@/util/fetcher";
+import { useQuery } from "@tanstack/react-query";
+
+export interface Balance {
+    amount: number;
+    date: string;
+    identifier: string;
+    layer_name: string;
+    token_name: string;
+}
+
+interface Props {
+    queryString?: string
+}
+
+export default function useGetBalances({ queryString }: Props = {}) {
+    const response = useQuery<Balance[]>({
+        queryKey: [queryString ? `get_balances${queryString}` : 'get_balances'],
+        queryFn: () => {
+            return fetcher(`${process.env.NEXT_PUBLIC_API_URL}/get_balances${queryString ?? ''}`);
+        }
+    })
+
+    return response
+}

--- a/hooks/use-get-balances.tsx
+++ b/hooks/use-get-balances.tsx
@@ -10,16 +10,18 @@ export interface Balance {
 }
 
 interface Props {
-    queryString?: string
+    queryString?: string;
 }
 
 export default function useGetBalances({ queryString }: Props = {}) {
     const response = useQuery<Balance[]>({
-        queryKey: [queryString ? `get_balances${queryString}` : 'get_balances'],
+        queryKey: [queryString ? `get_balances${queryString}` : "get_balances"],
         queryFn: () => {
-            return fetcher(`${process.env.NEXT_PUBLIC_API_URL}/get_balances${queryString ?? ''}`);
-        }
-    })
+            return fetcher(
+                `${process.env.NEXT_PUBLIC_API_URL}/get_balances${queryString ?? ""}`,
+            );
+        },
+    });
 
-    return response
+    return response;
 }


### PR DESCRIPTION
This PR:

1) Moves the multiple get_balances calls to a shared hook.
2) Uses new hook in layers table with query parameter to get latest TVL values for each layer.
3) Adds a condition to display realtime data for layer in relevant cell if it exists, otherwise uses fallback .json value.