### PR TITLE
Use layer_slug instead of layer_name

### DIFF
--- a/components/charts/project-tvl-chart.tsx
+++ b/components/charts/project-tvl-chart.tsx
@@ -40,7 +40,7 @@ export default function ProjectTVLChart() {
     });
 
     const { data } = useGetTokentvlHistoricalAll({
-        queryString: `?layer_name=ilike.${slug}`,
+        queryString: `?layer_slug=ilike.${slug}`,
     });
 
     const { data: pricesData, isLoading, error } = useGetCurrentPrices();
@@ -163,8 +163,6 @@ export default function ProjectTVLChart() {
     }, [data, dateRange, tokens]);
 
     if (data?.length === 0) return null;
-
-    console.log(data);
 
     return (
         <Card className="bg-background mb-6">

--- a/components/infrastructure/categories.tsx
+++ b/components/infrastructure/categories.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useMemo } from "react";
+import { InfrastructureProject } from "@/content/props";
+import useGetLayertvlCurrentAll from "@/hooks/use-get-layertvl-current-all";
+
+const Categories: React.FC<{ infrastructure: InfrastructureProject }> = ({
+    infrastructure,
+}) => {
+    // TODO: Come back and use the right hook
+    const { data: balances } = useGetLayertvlCurrentAll({
+        queryString: `?layer_slug=ilike.${infrastructure.slug}`,
+    });
+
+    const matchingBalance = useMemo(() => {
+        if (!balances) return null;
+
+        return balances.find(
+            (balance) => balance.layer_slug === infrastructure.slug,
+        );
+    }, [balances, infrastructure.slug]);
+
+    return (
+        <div className="flex gap-12 w-full">
+            <div className="flex-col justify-center items-start">
+                <div className="text-text_primary text-sm leading-tight">
+                    Status
+                </div>
+                <div className="text-text_header">{infrastructure.live}</div>
+            </div>
+            <div className="flex-col justify-center items-start">
+                <div className="text-text_primary text-sm leading-tight">
+                    Type
+                </div>
+                <div className="text-text_header">
+                    {infrastructure.entityType}
+                </div>
+            </div>
+            <div className="flex-col justify-center items-start">
+                <div className="text-text_primary text-sm leading-tight">
+                    Purpose
+                </div>
+                <div className="text-text_header">{infrastructure.purpose}</div>
+            </div>
+            <div className="flex-col justify-center items-start">
+                <div className="text-text_primary text-sm leading-tight">
+                    TVL
+                </div>
+                <div className="text-text_header">
+                    ₿
+                    {matchingBalance
+                        ? matchingBalance.total_amount.toLocaleString("en-US", {
+                              minimumFractionDigits: 0,
+                              maximumFractionDigits: 0,
+                          })
+                        : null}
+                </div>
+            </div>
+            <div className="flex-col justify-center items-start">
+                <div className="text-text_primary text-sm leading-tight">
+                    Associated Layers
+                </div>
+                <div className="text-text_header">
+                    {infrastructure.associatedLayers}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Categories;

--- a/components/infrastructure/infrastructureOverview.tsx
+++ b/components/infrastructure/infrastructureOverview.tsx
@@ -1,38 +1,8 @@
 import React from "react";
 import { parseTextWithLinks } from "@/util/parseTextWithLinks";
 import { InfrastructureProject } from "@/content/props";
-import ProjectLinks from "../project-links";
-
-const Categories: React.FC<{ infrastructure: InfrastructureProject }> = ({
-    infrastructure,
-}) => {
-    return (
-        <div className="flex gap-12 w-full">
-            <div className="flex-col justify-center items-start">
-                <div className="text-text_primary text-sm leading-tight">
-                    Type
-                </div>
-                <div className="text-text_header">
-                    {infrastructure.entityType}
-                </div>
-            </div>
-            <div className="flex-col justify-center items-start">
-                <div className="text-text_primary text-sm leading-tight">
-                    Purpose
-                </div>
-                <div className="text-text_header">{infrastructure.purpose}</div>
-            </div>
-            <div className="flex-col justify-center items-start">
-                <div className="text-text_primary text-sm leading-tight">
-                    Associated Layers
-                </div>
-                <div className="text-text_header">
-                    {infrastructure.associatedLayers}
-                </div>
-            </div>
-        </div>
-    );
-};
+import ProjectLinks from "@/components/project-links";
+import Categories from "@/components/infrastructure/categories";
 
 const Description: React.FC<{ infrastructure: InfrastructureProject }> = ({
     infrastructure,

--- a/components/layer/categories.tsx
+++ b/components/layer/categories.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import useGetLayertvlHistoricalAll from "@/hooks/use-get-layertvl-current-all";
 import { useMemo } from "react";
-import { LayerProject, Project } from "@/content/props";
+import { LayerProject } from "@/content/props";
+import useGetLayertvlCurrentAll from "@/hooks/use-get-layertvl-current-all";
 
-const Categories: React.FC<{ layer: Project }> = ({ layer }) => {
-    const { data: balances } = useGetLayertvlHistoricalAll();
+const Categories: React.FC<{ layer: LayerProject }> = ({ layer }) => {
+    const { data: balances } = useGetLayertvlCurrentAll({
+        queryString: `?layer_slug=ilike.${layer.slug}`,
+    });
 
     const matchingBalance = useMemo(() => {
         if (!balances) return null;
+
         return balances.find((balance) => balance.layer_slug === layer.slug);
     }, [balances, layer.slug]);
 
@@ -45,7 +48,7 @@ const Categories: React.FC<{ layer: Project }> = ({ layer }) => {
                               minimumFractionDigits: 0,
                               maximumFractionDigits: 0,
                           })
-                        : (layer as LayerProject).btcLocked}
+                        : layer.btcLocked}
                 </div>
             </div>
         </div>

--- a/content/infrastructures/wbtc.ts
+++ b/content/infrastructures/wbtc.ts
@@ -61,7 +61,7 @@ const wbtc: InfrastructureProject = {
             content: [
                 {
                     content:
-                        "The relevant smart contracts for tBTC are linked below:\n\n[wBTC Ethereum smart contract](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)\n\n[wBTC Base smart contract](https://basescan.org/address/0x1ceA84203673764244E05693e42E6Ace62bE9BA5)\n\nOther chains, including Tron and Osmosis, [listed here](https://wbtc.network/dashboard/order-book/wbtc),"
+                        "The relevant smart contracts for tBTC are linked below:\n\n[wBTC Ethereum smart contract](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)\n\n[wBTC Base smart contract](https://basescan.org/address/0x1ceA84203673764244E05693e42E6Ace62bE9BA5)\n\nOther chains, including Tron and Osmosis, [listed here](https://wbtc.network/dashboard/order-book/wbtc),",
                 },
             ],
         },
@@ -84,7 +84,7 @@ const wbtc: InfrastructureProject = {
             tier: "",
             title: "Users trust permissioned entities with the custody of their BTC.",
             content:
-                "The Bitcoin backing wBTC is custodied by permissioned entities. BitGo and BiT Global are the participants responsible with custodying the funds backing wBTC across the various networks its deployed on.\n\nThe wallets holding the bitcoin backing wBTC are dispersed between Hong Kong, Singapore, and the United States."
+                "The Bitcoin backing wBTC is custodied by permissioned entities. BitGo and BiT Global are the participants responsible with custodying the funds backing wBTC across the various networks its deployed on.\n\nThe wallets holding the bitcoin backing wBTC are dispersed between Hong Kong, Singapore, and the United States.",
         },
         {
             category: AssessmentCategory.Signing,

--- a/util/infrastructure_index.tsx
+++ b/util/infrastructure_index.tsx
@@ -50,7 +50,6 @@ const pump: InfrastructureProject = pumpProject;
 const fire: InfrastructureProject = fireProject;
 const bitcoinos: InfrastructureProject = bitcoinosProject;
 
-
 export const allInfrastructures: InfrastructureProject[] = [
     cashu,
     fedimint,


### PR DESCRIPTION
This PR opts to use layer_slug instead of layer_name in operator query params for fetching data for project pages.

Bsquared, Fractal, and Rollux do not have data. ICP, Lightning, and Liquid are populating.

Status and TVL have also been added to infra project pages. TVL is wired up but not returning current TVL data.