### PR TITLE
adding non bitcoin-aligned layers based on TVL threshold

### DIFF
--- a/content/layers/avalanche.ts
+++ b/content/layers/avalanche.ts
@@ -1,0 +1,95 @@
+import {
+    LayerProject,
+    Type,
+    LiveStatus,
+    RiskFactor,
+    EntityType,
+    Site,
+    RiskSection,
+    ContentSection,
+    RiskCategory,
+} from "../props";
+
+const avalanche: LayerProject = {
+    type: Type.Layer,
+    slug: "avalanche",
+    title: "Avalanche",
+    entityType: EntityType.Sidechain,
+    live: LiveStatus.Mainnet,
+    staking: false,
+    liquidStaking: false,
+    bridge: false,
+    underReview: true,
+    riskFactors: ["", "", "", ""],
+    btcLocked: 0,
+    nativeToken: "-",
+    feeToken: "ETH",
+    bitcoinOnly: false,
+    links: [
+        {
+            text: Site.Website,
+            url: "https://usecorn.com/",
+        },
+        {
+            text: Site.Docs,
+            url: "https://docs.usecorn.com/docs/developers/introduction",
+        },
+        {
+            text: Site.Explorer,
+            url: "https://cornscan.io/",
+        },
+        {
+            text: Site.GitHub,
+            url: "https://github.com/usecorn",
+        },
+        {
+            text: Site.Twitter,
+            url: "https://x.com/use_corn",
+        },
+    ],
+    description:
+        "Arbitrum is an Ethereum rollup that that supports a variety of wrapped BTC tokens.",
+    riskAnalysis: [
+        {
+            category: RiskCategory.UnilateralExits,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.DataAvailability,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.BlockProduction,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.StateValidation,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+    ],
+    sections: [
+        {
+            id: "underreview",
+            title: "Under review",
+            content: [
+                {
+                    content: "This project is under review.",
+                },
+            ],
+        },
+    ],
+};
+
+export default avalanche;

--- a/content/layers/base.ts
+++ b/content/layers/base.ts
@@ -1,0 +1,95 @@
+import {
+    LayerProject,
+    Type,
+    LiveStatus,
+    RiskFactor,
+    EntityType,
+    Site,
+    RiskSection,
+    ContentSection,
+    RiskCategory,
+} from "../props";
+
+const base: LayerProject = {
+    type: Type.Layer,
+    slug: "base",
+    title: "Base",
+    entityType: EntityType.EthereumRollup,
+    live: LiveStatus.Mainnet,
+    staking: false,
+    liquidStaking: false,
+    bridge: false,
+    underReview: true,
+    riskFactors: ["", "", "", ""],
+    btcLocked: 0,
+    nativeToken: "-",
+    feeToken: "ETH",
+    bitcoinOnly: false,
+    links: [
+        {
+            text: Site.Website,
+            url: "https://usecorn.com/",
+        },
+        {
+            text: Site.Docs,
+            url: "https://docs.usecorn.com/docs/developers/introduction",
+        },
+        {
+            text: Site.Explorer,
+            url: "https://cornscan.io/",
+        },
+        {
+            text: Site.GitHub,
+            url: "https://github.com/usecorn",
+        },
+        {
+            text: Site.Twitter,
+            url: "https://x.com/use_corn",
+        },
+    ],
+    description:
+        "Arbitrum is an Ethereum rollup that that supports a variety of wrapped BTC tokens.",
+    riskAnalysis: [
+        {
+            category: RiskCategory.UnilateralExits,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.DataAvailability,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.BlockProduction,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.StateValidation,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+    ],
+    sections: [
+        {
+            id: "underreview",
+            title: "Under review",
+            content: [
+                {
+                    content: "This project is under review.",
+                },
+            ],
+        },
+    ],
+};
+
+export default base;

--- a/content/layers/bsc.ts
+++ b/content/layers/bsc.ts
@@ -1,0 +1,95 @@
+import {
+    LayerProject,
+    Type,
+    LiveStatus,
+    RiskFactor,
+    EntityType,
+    Site,
+    RiskSection,
+    ContentSection,
+    RiskCategory,
+} from "../props";
+
+const bsc: LayerProject = {
+    type: Type.Layer,
+    slug: "bsc",
+    title: "Binance Smart Chain",
+    entityType: EntityType.Sidechain,
+    live: LiveStatus.Mainnet,
+    staking: false,
+    liquidStaking: false,
+    bridge: false,
+    underReview: true,
+    riskFactors: ["", "", "", ""],
+    btcLocked: 0,
+    nativeToken: "-",
+    feeToken: "ETH",
+    bitcoinOnly: false,
+    links: [
+        {
+            text: Site.Website,
+            url: "https://usecorn.com/",
+        },
+        {
+            text: Site.Docs,
+            url: "https://docs.usecorn.com/docs/developers/introduction",
+        },
+        {
+            text: Site.Explorer,
+            url: "https://cornscan.io/",
+        },
+        {
+            text: Site.GitHub,
+            url: "https://github.com/usecorn",
+        },
+        {
+            text: Site.Twitter,
+            url: "https://x.com/use_corn",
+        },
+    ],
+    description:
+        "Arbitrum is an Ethereum rollup that that supports a variety of wrapped BTC tokens.",
+    riskAnalysis: [
+        {
+            category: RiskCategory.UnilateralExits,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.DataAvailability,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.BlockProduction,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.StateValidation,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+    ],
+    sections: [
+        {
+            id: "underreview",
+            title: "Under review",
+            content: [
+                {
+                    content: "This project is under review.",
+                },
+            ],
+        },
+    ],
+};
+
+export default bsc;

--- a/content/layers/ethereum.ts
+++ b/content/layers/ethereum.ts
@@ -1,0 +1,95 @@
+import {
+    LayerProject,
+    Type,
+    LiveStatus,
+    RiskFactor,
+    EntityType,
+    Site,
+    RiskSection,
+    ContentSection,
+    RiskCategory,
+} from "../props";
+
+const ethereum: LayerProject = {
+    type: Type.Layer,
+    slug: "ethereum",
+    title: "Ethereum",
+    entityType: EntityType.Sidechain,
+    live: LiveStatus.Mainnet,
+    staking: false,
+    liquidStaking: false,
+    bridge: false,
+    underReview: true,
+    riskFactors: ["", "", "", ""],
+    btcLocked: 0,
+    nativeToken: "-",
+    feeToken: "ETH",
+    bitcoinOnly: false,
+    links: [
+        {
+            text: Site.Website,
+            url: "https://usecorn.com/",
+        },
+        {
+            text: Site.Docs,
+            url: "https://docs.usecorn.com/docs/developers/introduction",
+        },
+        {
+            text: Site.Explorer,
+            url: "https://cornscan.io/",
+        },
+        {
+            text: Site.GitHub,
+            url: "https://github.com/usecorn",
+        },
+        {
+            text: Site.Twitter,
+            url: "https://x.com/use_corn",
+        },
+    ],
+    description:
+        "Arbitrum is an Ethereum rollup that that supports a variety of wrapped BTC tokens.",
+    riskAnalysis: [
+        {
+            category: RiskCategory.UnilateralExits,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.DataAvailability,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.BlockProduction,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.StateValidation,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+    ],
+    sections: [
+        {
+            id: "underreview",
+            title: "Under review",
+            content: [
+                {
+                    content: "This project is under review.",
+                },
+            ],
+        },
+    ],
+};
+
+export default ethereum;

--- a/content/layers/optimism.ts
+++ b/content/layers/optimism.ts
@@ -1,0 +1,95 @@
+import {
+    LayerProject,
+    Type,
+    LiveStatus,
+    RiskFactor,
+    EntityType,
+    Site,
+    RiskSection,
+    ContentSection,
+    RiskCategory,
+} from "../props";
+
+const optimism: LayerProject = {
+    type: Type.Layer,
+    slug: "optimism",
+    title: "Optimism",
+    entityType: EntityType.EthereumRollup,
+    live: LiveStatus.Mainnet,
+    staking: false,
+    liquidStaking: false,
+    bridge: false,
+    underReview: true,
+    riskFactors: ["", "", "", ""],
+    btcLocked: 0,
+    nativeToken: "-",
+    feeToken: "ETH",
+    bitcoinOnly: false,
+    links: [
+        {
+            text: Site.Website,
+            url: "https://usecorn.com/",
+        },
+        {
+            text: Site.Docs,
+            url: "https://docs.usecorn.com/docs/developers/introduction",
+        },
+        {
+            text: Site.Explorer,
+            url: "https://cornscan.io/",
+        },
+        {
+            text: Site.GitHub,
+            url: "https://github.com/usecorn",
+        },
+        {
+            text: Site.Twitter,
+            url: "https://x.com/use_corn",
+        },
+    ],
+    description:
+        "Arbitrum is an Ethereum rollup that that supports a variety of wrapped BTC tokens.",
+    riskAnalysis: [
+        {
+            category: RiskCategory.UnilateralExits,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.DataAvailability,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.BlockProduction,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.StateValidation,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+    ],
+    sections: [
+        {
+            id: "underreview",
+            title: "Under review",
+            content: [
+                {
+                    content: "This project is under review.",
+                },
+            ],
+        },
+    ],
+};
+
+export default optimism;

--- a/content/layers/polygon.ts
+++ b/content/layers/polygon.ts
@@ -1,0 +1,95 @@
+import {
+    LayerProject,
+    Type,
+    LiveStatus,
+    RiskFactor,
+    EntityType,
+    Site,
+    RiskSection,
+    ContentSection,
+    RiskCategory,
+} from "../props";
+
+const polygon: LayerProject = {
+    type: Type.Layer,
+    slug: "polygon",
+    title: "Polygon",
+    entityType: EntityType.Sidechain,
+    live: LiveStatus.Mainnet,
+    staking: false,
+    liquidStaking: false,
+    bridge: false,
+    underReview: true,
+    riskFactors: ["", "", "", ""],
+    btcLocked: 0,
+    nativeToken: "-",
+    feeToken: "ETH",
+    bitcoinOnly: false,
+    links: [
+        {
+            text: Site.Website,
+            url: "https://usecorn.com/",
+        },
+        {
+            text: Site.Docs,
+            url: "https://docs.usecorn.com/docs/developers/introduction",
+        },
+        {
+            text: Site.Explorer,
+            url: "https://cornscan.io/",
+        },
+        {
+            text: Site.GitHub,
+            url: "https://github.com/usecorn",
+        },
+        {
+            text: Site.Twitter,
+            url: "https://x.com/use_corn",
+        },
+    ],
+    description:
+        "Arbitrum is an Ethereum rollup that that supports a variety of wrapped BTC tokens.",
+    riskAnalysis: [
+        {
+            category: RiskCategory.UnilateralExits,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.DataAvailability,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.BlockProduction,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+        {
+            category: RiskCategory.StateValidation,
+            score: 0,
+            tier: "",
+            title: "",
+            content: "",
+        },
+    ],
+    sections: [
+        {
+            id: "underreview",
+            title: "Under review",
+            content: [
+                {
+                    content: "This project is under review.",
+                },
+            ],
+        },
+    ],
+};
+
+export default polygon;

--- a/util/layer_index.tsx
+++ b/util/layer_index.tsx
@@ -50,6 +50,12 @@ import sparkProject from "../content/layers/spark";
 import barkProject from "../content/layers/bark";
 import clarkProject from "../content/layers/clark";
 import arbitrumProject from "../content/layers/arbitrum";
+import baseProject from "../content/layers/base";
+import bscProject from "../content/layers/bsc";
+import optimismProject from "../content/layers/optimism";
+import ethereumProject from "../content/layers/ethereum";
+import polygonProject from "../content/layers/polygon";
+import avalancheProject from "../content/layers/avalanche";
 
 const core: LayerProject = coreProject;
 const internetcomputer: LayerProject = internetcomputerProject;
@@ -101,6 +107,12 @@ const spark: LayerProject = sparkProject;
 const bark: LayerProject = barkProject;
 const clark: LayerProject = clarkProject;
 const arbitrum: LayerProject = arbitrumProject;
+const avalanche: LayerProject = avalancheProject;
+const base: LayerProject = baseProject;
+const bsc: LayerProject = bscProject;
+const optimism: LayerProject = optimismProject;
+const ethereum: LayerProject = ethereumProject;
+const polygon: LayerProject = polygonProject;
 
 export const allLayers: LayerProject[] = [
     core,
@@ -145,6 +157,13 @@ export const allLayers: LayerProject[] = [
     spark,
     bark,
     clark,
+    arbitrum,
+    avalanche,
+    base,
+    bsc,
+    optimism,
+    ethereum,
+    polygon,
 ];
 
 export const allLayerSlugs: string[] = allLayers.map((layer) => layer.slug);


### PR DESCRIPTION
adding alternative L1s to the site because the amount of tvl they have locked.

@RedVelvetZip can you test this locally and see if layer + wrapper charts align? charts aren't building for me.