### PR TITLE
Fix token addr edge case

### DIFF
--- a/components/project-contract-addresses.tsx
+++ b/components/project-contract-addresses.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import ImageWithFallback from "./tables/image-with-fallback";
 
 const truncateAddress = (address: string) => {
-    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+    return ${address.slice(0, 6)}...${address.slice(-4)};
 };
 
 interface Props {
@@ -30,53 +30,69 @@ const AddressItem = ({
     item: any;
     showBorder: boolean;
     isLayer: boolean;
-}) => (
-    <div className={`${showBorder ? "border-b" : ""} py-4`}>
-        <div className="self-stretch justify-between items-center inline-flex">
-            <div className="!text-muted-foreground mb-1 flex items-center">
-                <ImageWithFallback
-                    slug={isLayer ? item.token_slug : item.network_slug}
-                    folder="logos"
-                    altText={isLayer ? item.token_name : item.network_name}
-                    width={20}
-                    height={20}
-                />
-                <p className="ml-2">
-                    {isLayer ? item.token_name : item.network_name}
-                </p>
+}) => {
+    const customUrls: { [key: string]: string } = {
+        "Rootstock-RBTC": "https://explorer.rootstock.io/",
+        "xLink-aBTC":
+            "https://explorer.hiro.so/token/SP2XD7417HGPRTREMKF748VNEQPDRR0RMANB7X1NK.token-abtc?chain=mainnet",
+        "Alex-xBTC":
+            "https://explorer.hiro.so/token/SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin?chain=mainnet",
+        "Stacks-sBTC":
+            "https://explorer.hiro.so/token/SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token?chain=mainnet",
+    };
+
+    const url =
+        customUrls[item.token_slug] ?? ${item.explorer}${item.token_address};
+
+    return (
+        <div className={${showBorder ? "border-b" : ""} py-4}>
+            <div className="self-stretch justify-between items-center inline-flex">
+                <div className="!text-muted-foreground mb-1 flex items-center">
+                    <ImageWithFallback
+                        slug={isLayer ? item.token_slug : item.network_slug}
+                        folder="logos"
+                        altText={isLayer ? item.token_name : item.network_name}
+                        width={20}
+                        height={20}
+                    />
+                    <p className="ml-2">
+                        {isLayer ? item.token_name : item.network_name}
+                    </p>
+                </div>
+            </div>
+            <div className="!text-foreground flex flex-wrap text-wrap break-all">
+                <Link
+                    href={url}
+                    target="_blank"
+                    className="flex items-center gap-1 hover:underline"
+                >
+                    {customUrls[item.token_slug] ? (
+                        <span className="pl-7">{url}</span>
+                    ) : (
+                        <>
+                            <span className="sm:hidden pl-7">
+                                {truncateAddress(item.token_address)}
+                            </span>
+                            <span className="hidden sm:inline pl-7">
+                                {item.token_address}
+                            </span>
+                        </>
+                    )}
+                    <ExternalLinkIcon className="h-4 w-4 ml-2" />
+                </Link>
             </div>
         </div>
-        <div className="!text-foreground flex flex-wrap text-wrap break-all">
-            <Link
-                href={`${item.explorer}${item.token_address}${
-                    item.token_slug === "Alex-xBTC" ||
-                    item.token_slug === "xLink-aBTC"
-                        ? "?chain=mainnet"
-                        : ""
-                }`}
-                target="_blank"
-                className="flex items-center gap-1 hover:underline"
-            >
-                <span className="sm:hidden pl-7">
-                    {truncateAddress(item.token_address)}
-                </span>
-                <span className="hidden sm:inline pl-7">
-                    {item.token_address}
-                </span>
-                <ExternalLinkIcon className="h-4 w-4 ml-2" />
-            </Link>
-        </div>
-    </div>
-);
+    );
+};
 
 export default function ProjectContractAddresses({ slug, isLayer }: Props) {
     const [isOpen, setIsOpen] = useState(false);
 
     const { data, isLoading, error } = useQuery({
-        queryKey: [`contract-addresses-${slug}`],
+        queryKey: [contract-addresses-${slug}],
         queryFn: () =>
             fetcher(
-                `${process.env.NEXT_PUBLIC_API_URL}/current_supplies_by_tokenimpl?${isLayer ? `network_slug=ilike.${slug}` : `token_slug=ilike.${slug}`}`,
+                ${process.env.NEXT_PUBLIC_API_URL}/current_supplies_by_tokenimpl?${isLayer ? network_slug=ilike.${slug} : token_slug=ilike.${slug}},
             ),
     });
 

--- a/components/project-contract-addresses.tsx
+++ b/components/project-contract-addresses.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import ImageWithFallback from "./tables/image-with-fallback";
 
 const truncateAddress = (address: string) => {
-    return ${address.slice(0, 6)}...${address.slice(-4)};
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
 interface Props {
@@ -27,25 +27,33 @@ const AddressItem = ({
     showBorder,
     isLayer,
 }: {
-    item: any;
+    item: {
+        token_slug: string;
+        explorer: string;
+        token_address: string;
+        token_name: string;
+        network_slug: string;
+        network_name: string;
+    };
     showBorder: boolean;
     isLayer: boolean;
 }) => {
     const customUrls: { [key: string]: string } = {
-        "Rootstock-RBTC": "https://explorer.rootstock.io/",
-        "xLink-aBTC":
+        "Rootstock-RBTC_Rootstock": "https://explorer.rootstock.io/",
+        "xLink-aBTC_Stacks":
             "https://explorer.hiro.so/token/SP2XD7417HGPRTREMKF748VNEQPDRR0RMANB7X1NK.token-abtc?chain=mainnet",
-        "Alex-xBTC":
+        "Alex-xBTC_Stacks":
             "https://explorer.hiro.so/token/SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin?chain=mainnet",
-        "Stacks-sBTC":
+        "Stacks-sBTC_Stacks":
             "https://explorer.hiro.so/token/SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token?chain=mainnet",
     };
 
     const url =
-        customUrls[item.token_slug] ?? ${item.explorer}${item.token_address};
+        customUrls[`${item.token_slug}_${item.network_slug}`] ??
+        `${item.explorer}${item.token_address}`;
 
     return (
-        <div className={${showBorder ? "border-b" : ""} py-4}>
+        <div className={`${showBorder ? "border-b" : ""} py-4`}>
             <div className="self-stretch justify-between items-center inline-flex">
                 <div className="!text-muted-foreground mb-1 flex items-center">
                     <ImageWithFallback
@@ -89,10 +97,10 @@ export default function ProjectContractAddresses({ slug, isLayer }: Props) {
     const [isOpen, setIsOpen] = useState(false);
 
     const { data, isLoading, error } = useQuery({
-        queryKey: [contract-addresses-${slug}],
+        queryKey: [`contract-addresses-${slug}`],
         queryFn: () =>
             fetcher(
-                ${process.env.NEXT_PUBLIC_API_URL}/current_supplies_by_tokenimpl?${isLayer ? network_slug=ilike.${slug} : token_slug=ilike.${slug}},
+                `${process.env.NEXT_PUBLIC_API_URL}/current_supplies_by_tokenimpl?${isLayer ? `network_slug=ilike.${slug}` : `token_slug=ilike.${slug}`}`,
             ),
     });
 


### PR DESCRIPTION
Previously:
-our edge case solution for displaying token contract addresses was only taking token_slug into account (e.g., Alex-xBTC). the issue here is that Alex-xBTC exists on multiple networks (Stacks, Core) and the workaround we were going for was only relevant on Stacks
-our workaround only allowed for us to _append_ more text at the end of the url, rather than submit a completely different url

With this fix:
-edge cases are decided based on full token_implementation, (eg project-ticker_network, Alex-xBTC_Stacks) to avoid the mixup with the Core impl of alex's xbtc
-now we can add any url in for edge cases. this helps us clear up the Rootstock-RBTC_Rootstock issue as it's the native token of the network and has no explorer page, only a main dashboard we can show